### PR TITLE
Allow per-resources defaults to be passed in via second arg

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4,6 +4,10 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
 var _tahoe = require('tahoe');
 
 var _pluralize = require('pluralize');
@@ -20,12 +24,12 @@ var _lodash2 = _interopRequireDefault(_lodash);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var resourceToActions = function resourceToActions(resourceName, resource) {
+var resourceToActions = function resourceToActions(resourceName, resource, defaults) {
   var model = new _normalizr.Schema(resourceName);
   // model.define(mapValues(resource.model.relationships, relationshipMap))
 
   return (0, _lodash2.default)(resource.endpoints, function (prev, _endpoint) {
-    prev[_endpoint.name] = (0, _tahoe.createAction)({
+    prev[_endpoint.name] = (0, _tahoe.createAction)((0, _extends3.default)({
       endpoint: function endpoint(opt) {
         return (0, _templateUrl2.default)(_endpoint.path, opt);
       },
@@ -33,14 +37,15 @@ var resourceToActions = function resourceToActions(resourceName, resource) {
       model: model,
       collection: !_endpoint.instance,
       credentials: 'include'
-    });
+    }, defaults));
     return prev;
   }, {});
 };
 
 exports.default = function (resources) {
+  var defaults = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
   return (0, _lodash2.default)(resources.toJS ? resources.toJS() : resources, function (prev, v, k) {
-    prev[(0, _pluralize.plural)(k)] = resourceToActions(k, v);
+    prev[(0, _pluralize.plural)(k)] = resourceToActions(k, v, defaults);
     return prev;
   }, {});
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,24 +4,27 @@ import { Schema } from 'normalizr'
 import template from 'template-url'
 import reduce from 'lodash.reduce'
 
-const resourceToActions = (resourceName, resource) => {
+const resourceToActions = (resourceName, resource, defaults) => {
   let model = new Schema(resourceName)
   // model.define(mapValues(resource.model.relationships, relationshipMap))
 
   return reduce(resource.endpoints, (prev, endpoint) => {
     prev[endpoint.name] = createAction({
-      endpoint: (opt) => template(endpoint.path, opt),
-      method: endpoint.method,
-      model: model,
-      collection: !endpoint.instance,
-      credentials: 'include'
+      ...{
+        endpoint: (opt) => template(endpoint.path, opt),
+        method: endpoint.method,
+        model: model,
+        collection: !endpoint.instance,
+        credentials: 'include'
+      },
+      ...defaults
     })
     return prev
   }, {})
 }
 
-export default (resources) =>
+export default (resources, defaults = {}) =>
   reduce((resources.toJS ? resources.toJS() : resources), (prev, v, k) => {
-    prev[plural(k)] = resourceToActions(k, v)
+    prev[plural(k)] = resourceToActions(k, v, defaults)
     return prev
   }, {})


### PR DESCRIPTION
Use-case: `createAPIActions(resources, {headers: getAuthHeaders}`

Relies on shastajs/tahoe#8
