### PR TITLE
add support for rootUrl base url

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18,6 +18,10 @@ var _templateUrl = require('template-url');
 
 var _templateUrl2 = _interopRequireDefault(_templateUrl);
 
+var _urlJoin = require('url-join');
+
+var _urlJoin2 = _interopRequireDefault(_urlJoin);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var replaceWithActions = function replaceWithActions(out, start, options) {
@@ -29,6 +33,7 @@ var replaceWithActions = function replaceWithActions(out, start, options) {
     }
     out[k] = (0, _tahoe.createAction)((0, _extends3.default)({
       endpoint: function endpoint(opt) {
+        if (options.rootUrl) return (0, _urlJoin2.default)(options.rootUrl, (0, _templateUrl2.default)(v.path, opt));
         return (0, _templateUrl2.default)(v.path, opt);
       },
       method: v.method,

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "tahoe": "^1.0.0",
-    "template-url": "^1.0.0"
+    "template-url": "^1.0.0",
+    "url-join": "^2.0.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { createAction } from 'tahoe'
 import template from 'template-url'
+import uJoin from 'url-join'
 
 const replaceWithActions = (out, start, options) => {
   Object.keys(start).forEach((k) => {
@@ -10,7 +11,7 @@ const replaceWithActions = (out, start, options) => {
     }
     out[k] = createAction({
       endpoint: (opt) => {
-        if (options.rootUrl) return `${options.rootUrl}${template(v.path, opt)}`
+        if (options.rootUrl) return uJoin(options.rootUrl, template(v.path, opt))
         return template(v.path, opt)
       },
       method: v.method,

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,10 @@ const replaceWithActions = (out, start, options) => {
       return
     }
     out[k] = createAction({
-      endpoint: (opt) => template(v.path, opt),
+      endpoint: (opt) => {
+        if (options.rootUrl) return `${options.rootUrl}${template(v.path, opt)}`
+        return template(v.path, opt)
+      },
       method: v.method,
       credentials: 'include',
       ...options


### PR DESCRIPTION
This adds an optional `rootUrl` parameter:
```js
{
  rootUrl: 'http://api.systems.com'
}

// => http://api.systems.com/table/:id instead of /table/:id
```

